### PR TITLE
typo in Structure.read

### DIFF
--- a/src/packet.coffee
+++ b/src/packet.coffee
@@ -284,7 +284,7 @@ module.exports.Parser = class Parser extends Packet
       # The pattern is set to null, our terminal condition, because the callback
       # may specify a subsequent packet to parse.
       else if ++@patternIndex == @pattern.length
-        @fields.push(@pipeline(@pattern[@patternIndex -1 ], @fields.pop()))
+        @fields.push(@pipeline(@pattern[@patternIndex - 1 ], @fields.pop()))
 
         @fields.push(this)
         for p in @user or []


### PR DESCRIPTION
it looks like there was a typo in Structure.read that caused an impossible condition that assigned offset to callback if callback was a function and didn't exist!  i've changed it to what i think it should be but it's late so let me know if i'm wrong.
