### PR TITLE
Use npm hooks to build node-packet after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {   "name":             "packet"
 ,   "version":          "0.0.2"
 ,   "author":           "Alan Gutierrez <alan@prettyrobots.com> (http://www.prettyrobots.com/)"
-,   "contributors":     ["Aaron Qian <aq1018@gmail.com> (http://aaronqian.com)"]
+,   "contributors":     ["Aaron Qian <aq1018@gmail.com> (http://aaronqian.com)", "Ben Hockey <neonstalwart@gmail.com>"]
 ,   "main":             "./lib/packet"
 ,   "scripts": { "postinstall": "cake compile" }
 }


### PR DESCRIPTION
Without this, I had to manually build node-packet myself with the 1.x series of npm
