### PR TITLE
compilerRegularExpression CRLF fix

### DIFF
--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -31,7 +31,7 @@ var re = {};
 
 function compileRegularExpressions() {
   var name, $, lines, i, I, source;
-  source = require("fs").readFileSync(__filename, "utf8").split(/\n/);
+  source = require("fs").readFileSync(__filename, "utf8").split(/\r?\n/);
   for (i = 0, I = source.length; i < I; i++, $ = null) {
     for (; !$ && i < I; i++) {
       $ = /re\["([^"]+)"\s*\/\*\s*$/.exec(source[i]);


### PR DESCRIPTION
Fixed newline match in compileRegularExpression to add compatibility with windows and git core.autocrlf=true.
